### PR TITLE
wildfly vuln

### DIFF
--- a/containers/wildfly.html
+++ b/containers/wildfly.html
@@ -47,7 +47,7 @@ Use the pull string below for the version of this image you require.
 
 <td>docker pull icr.io/ibmz/wildfly@sha256:357a6cdda0e3694a221e9dd2d2fb65878546ae86c7e61b7258133b4cdcb57e7e</td>
 
-<td><a href="https://cloud.ibm.com/registry/images/eyJyZXBvIjoiaWNyLmlvL2libXovdWJ1bnR1IiwibG9uZ0RpZ2VzdCI6InNoYTI1NjowZmFlZmNhOWNmMzg1MTA5NmM5MjU3OGJkOTZiMDJhMzY5YTAwYjFiY2MyZmZmOTQ2N2EyZGZkYTRhNjMwMmY2In0=/issues" target="_blank">Vulnerability Report</a></td></tr>
+<td><a href="https://cloud.ibm.com/registry/images/eyJyZXBvIjoiaWNyLmlvL2libXovd2lsZGZseSIsImxvbmdEaWdlc3QiOiJzaGEyNTY6MzU3YTZjZGRhMGUzNjk0YTIyMWU5ZGQyZDJmYjY1ODc4NTQ2YWU4NmM3ZTYxYjcyNTgxMzNiNGNkY2I1N2U3ZSJ9/issues" target="_blank">Vulnerability Report</a></td></tr>
 <thead>
 
 <tr>


### PR DESCRIPTION
an issue with vulnerability generation caused incorrect vuln link. Does not appear to cascade to surrounding images.