### PR TITLE
addition of mongodb version 5.2

### DIFF
--- a/containers/index.html
+++ b/containers/index.html
@@ -74,7 +74,7 @@
 <tr"><td id="cols" class="name"><a href="kibana.html">kibana</a></td><td id="cols" class="tags">7.10</td></tr>
 <tr"><td id="cols" class="name"><a href="maven.html">maven</a></td><td id="cols" class="tags">3 3-eclipse-temurin 3-eclipse-temurin-17 3.9 3.9-eclipse-temurin 3.9-eclipse-temurin-17 3.9.0 3.9.0-eclipse-temurin 3.9.0-eclipse-temurin-17 eclipse-temurin, 3.8 3.8-eclipse-temurin 3.8-eclipse-temurin-17 3.8.6 3.8.6-eclipse-temurin 3.8.6-eclipse-temurin-17, 3.8.3-openjdk-17, 3.8.5 3.8.5-eclipse-temurin 3.8.5-eclipse-temurin-17</td></tr>
 <tr"><td id="cols" class="name"><a href="memcached.html">memcached</a></td><td id="cols" class="tags">1.6.14, 1.6.17 1.6.17-bullseye, 1 1-bullseye 1.6 1.6-bullseye 1.6.19 1.6.19-bullseye bullseye, 1.6.15 1.6.15-bullseye, 1.6.10, 1.6.8, 1.6.16 1.6.16-bullseye</td></tr>
-<tr"><td id="cols" class="name"><a href="mongo.html">mongo</a></td><td id="cols" class="tags">4.4.1</td></tr>
+<tr"><td id="cols" class="name"><a href="mongo.html">mongo</a></td><td id="cols" class="tags">4.4.1, 5.2</td></tr>
 <tr"><td id="cols" class="name"><a href="mule.html">mule</a></td><td id="cols" class="tags">4.4.0, 3.9.1</td></tr>
 <tr"><td id="cols" class="name"><a href="nginx.html">nginx</a></td><td id="cols" class="tags">1.21.3, 1.23.1, 1.21 1.21.6, 1 1.23 1.23.3 mainline</td></tr>
 <tr"><td id="cols" class="name"><a href="node.html">node</a></td><td id="cols" class="tags">17, 16, 18 18-bullseye 18.2 18.2-bullseye 18.2.0 18.2.0-bullseye bullseye current current-bullseye</td></tr>

--- a/containers/mongo.html
+++ b/containers/mongo.html
@@ -43,6 +43,12 @@ Use the pull string below for the version of this image you require.
 
 
 <table class="table table-striped table-bordered">
+<td>5.2</td>
+
+<td>docker pull icr.io/ibmz/mongo@sha256:540e86824960c68525d3f7043737d587b0fb843dfdde9e04b79cb7c10ab71b22</td>
+  
+<td><a href="https://cloud.ibm.com/registry/images/eyJyZXBvIjoiaWNyLmlvL2libXovbW9uZ28iLCJsb25nRGlnZXN0Ijoic2hhMjU2OjU0MGU4NjgyNDk2MGM2ODUyNWQzZjcwNDM3MzdkNTg3YjBmYjg0M2RmZGRlOWUwNGI3OWNiN2MxMGFiNzFiMjIifQ==/issues" target="_blank">Vulnerability Report</a></td><td>07-31-2023</td></tr>
+
 <td>4.4.1</td>
 
 <td>docker pull icr.io/ibmz/mongo@sha256:ffd897a362ef6f5be344f7a525ccbececac0cf8c496a39b8fd9bb134623cf258</td>
@@ -76,13 +82,13 @@ Use the pull string below for the version of this image you require.
 <p/>
 Start a mongo server instance where <code>some-mongo</code> is the name you want to assign to your container and 4.4.1 is the tag specifying the MongoDB version you want. See the list above for relevant tags.
 
-<p><pre><code>docker run --name {some-mongo} -d icr.io/ibmz/mongo:4.4.1</pre></code><br>
+<p><pre><code>docker run --name {some-mongo} -d icr.io/ibmz/mongo:5.2</pre></code><br>
 
 <h5>Connect to MongoDB from another Docker container</h5>
 
 The MongoDB server in the image listens on the standard MongoDB port, 27017, so connecting via Docker networks will be the same as connecting to a remote mongodb. The following example starts another MongoDB container instance and runs the mongo command line client against the original MongoDB container from the example above, allowing you to execute MongoDB statements against your database instance. Replace<code>{some-mongo}</code> witth the name of your original mongo container.<br>
 
-<p><pre><code>docker run -it --network some-network --rm icr.io/ibmz/mongo:4.4.1 mongo {some-mongo} test</pre></code><br>
+<p><pre><code>docker run -it --network some-network --rm icr.io/ibmz/mongo:5.2 mongo {some-mongo} test</pre></code><br>
 
 <h5>Using a custom MongoDB configuration file</h5>
 
@@ -93,9 +99,9 @@ needs to be specified. Create a custom configuration file and put the
 configuration file in the container by putting it in a Docker volume and
 then mounting that volume to the container. See the <a href="https://docs.mongodb.com/manual/reference/configuration-options/">MongoDB manual</a> for a full list of configuration file options.<br>
 <br/><p/>
-For example, the docker volume <code>mongo-config</code> contains the custom configuration file at <code>/mongod.conf</code>. Then run a <code>icr.io/ibmz/mongo:4.4.0</code> container with the mongo-config volume attached and the <code>--config /etc/mongo/mongod.conf</code> command passed in.<br>
+For example, the docker volume <code>mongo-config</code> contains the custom configuration file at <code>/mongod.conf</code>. Then run a <code>icr.io/ibmz/mongo:5.2</code> container with the mongo-config volume attached and the <code>--config /etc/mongo/mongod.conf</code> command passed in.<br>
 
-<br><p><pre><code>docker run --name custom-mongo-container -v mongo-config:/etc/mongo/ -d icr.io/ibmz/mongo:4.4.0 \
+<br><p><pre><code>docker run --name custom-mongo-container -v mongo-config:/etc/mongo/ -d icr.io/ibmz/mongo:5.2 \
         --config /etc/mongo/mongod.conf
 </pre></code><br>
 


### PR DESCRIPTION
This is a temporary manual update while our workflows are being maintained. 

mongodb version 5.2 (based in centos)
edits made to `mongo.html` and `index.html`
Signed-off-by: Charles Korpics <charles.korpics@ibm.com>